### PR TITLE
feat: handle graceful shutdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -275,7 +275,7 @@ app.use((error, req, res, next) => {
 });
 
 // 启动服务器
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
     console.log('🚀 直播成本计算系统已启动');
     console.log(`📍 访问地址: http://localhost:${PORT}`);
     console.log(`🔧 环境: ${process.env.NODE_ENV || 'development'}`);
@@ -283,14 +283,15 @@ app.listen(PORT, () => {
 });
 
 // 优雅关闭
-process.on('SIGTERM', () => {
-    console.log('收到 SIGTERM 信号，正在关闭服务器...');
-    process.exit(0);
-});
+const gracefulShutdown = (signal) => {
+    console.log(`收到 ${signal} 信号，正在关闭服务器...`);
+    server.close(() => {
+        console.log('服务器已关闭');
+        process.exit(0);
+    });
+};
 
-process.on('SIGINT', () => {
-    console.log('收到 SIGINT 信号，正在关闭服务器...');
-    process.exit(0);
-});
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- save server instance from `app.listen`
- gracefully close server on SIGTERM and SIGINT before exiting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d6784808321834423691b2a21c2