### PR TITLE
refactor: use Express built-in body parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const path = require('path');
 
 const app = express();
@@ -8,8 +7,8 @@ const PORT = process.env.PORT || 34145;
 
 // 中间件配置
 app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 // 静态文件服务，配置缓存策略
 app.use(express.static(path.join(__dirname, 'static'), {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
   "author": "开发团队",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
     "cors": "^2.8.5",
-    "body-parser": "^1.20.2"
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
## Summary
- replace body-parser middleware with express.json and express.urlencoded
- remove body-parser dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0dac0f4883218fb29046cdf7c69b